### PR TITLE
Add Studio file import

### DIFF
--- a/ldraw_file.py
+++ b/ldraw_file.py
@@ -2,6 +2,7 @@ import mathutils
 
 import os
 import re
+import zipfile
 
 from .import_options import ImportOptions
 from .filesystem import FileSystem
@@ -113,6 +114,11 @@ class LDrawFile:
         filepath = FileSystem.locate(filename)
         if filepath is None:
             return None
+
+        if filename.endswith('.io') and zipfile.is_zipfile(filename):
+            with zipfile.ZipFile(filename, 'r') as zip:
+                model_ldr = zip.read('model.ldr').decode('utf-8-sig')
+                return cls.__read_file(model_ldr.splitlines(), filename)
 
         with open(filepath, 'r', encoding='utf-8') as file:
             return cls.__read_file(file, filename)

--- a/operator_import.py
+++ b/operator_import.py
@@ -21,7 +21,7 @@ class IMPORT_OT_do_ldraw_import(bpy.types.Operator):
     filter_glob: bpy.props.StringProperty(
         name="Extensions",
         options={'HIDDEN'},
-        default="*.mpd;*.ldr;*.dat",
+        default="*.mpd;*.ldr;*.dat;*.io",
     )
 
     filepath: bpy.props.StringProperty(
@@ -459,7 +459,7 @@ class IMPORT_OT_do_ldraw_import(bpy.types.Operator):
 
 
 def build_import_menu(self, context):
-    self.layout.operator(IMPORT_OT_do_ldraw_import.bl_idname, text="LDraw (.mpd/.ldr/.l3b/.dat)")
+    self.layout.operator(IMPORT_OT_do_ldraw_import.bl_idname, text="LDraw (.mpd/.ldr/.l3b/.dat/.io)")
 
 
 classesToRegister = [


### PR DESCRIPTION
Your readme says:
> **A note about Stud.io projects**
> Stud.io project files are in actuality just password-protected zip files, but due to regulations related to DRM, importing Stud.io projects will not ever be implemented here, even though it would be relatively trivial.

I'm not sure if this has changed since you wrote that or what, but from what I can tell, they are *not* password-protected. You can just open them in any archive viewer (or indeed, python's `zipfile` library) without providing a password or anything. Thus, there is nothing that could be considered DRM.